### PR TITLE
Fix passing null Block to neighbor notifications during SoulCage update

### DIFF
--- a/src/main/java/info/tehnut/soulshardsrespawn/block/TileEntitySoulCage.java
+++ b/src/main/java/info/tehnut/soulshardsrespawn/block/TileEntitySoulCage.java
@@ -51,12 +51,12 @@ public class TileEntitySoulCage extends TileEntity implements ITickable {
         ActionResult<Binding> result = canSpawn();
         if (result.getType() != EnumActionResult.SUCCESS) {
             setState(false);
-            world.notifyNeighborsOfStateChange(pos, blockType, false);
+            world.notifyNeighborsOfStateChange(pos, getBlockType(), false);
             return;
         }
 
         setState(true);
-        world.notifyNeighborsOfStateChange(pos, blockType, false);
+        world.notifyNeighborsOfStateChange(pos, getBlockType(), false);
         activeTime++;
         IBlockState state = getWorld().getBlockState(getPos());
         getWorld().notifyBlockUpdate(getPos(), state, state, 3);


### PR DESCRIPTION
The vanilla TileEntity class has the protected `blockType`  field but accessing that field should be safely done through `getBlockType()` as the field itself is not assigned unless called by `getBlockType()` or by a subclass assigning itself. This is a [subtle issue with Sponge](https://github.com/SpongePowered/SpongeForge/issues/2787) as it's [attempting to provide as much information about what is going on during various processes of the game](https://github.com/SpongePowered/SpongeCommon/blob/bc1bc04d1843776030f6a5b69bea94a2d1d4646e/src/main/java/org/spongepowered/common/event/tracking/PhaseTracker.java#L652-L661), and one of those processes involves [getting the default block state from the passed `Block` that is performing the notification](https://github.com/SpongePowered/SpongeCommon/blob/bc1bc04d1843776030f6a5b69bea94a2d1d4646e/src/main/java/org/spongepowered/common/event/tracking/PhaseTracker.java#L692). To fix this, the fix involves simply calling getBlockType() here, instead of accessing the field directly.

A reduced copy of the printout that specifies the lines of the offending `null` can be seen here:
```
 java.lang.NullPointerException: null 
     org.spongepowered.common.event.tracking.PhaseTracker.notifyBlockOfStateChange(PhaseTracker.java:692)
     net.minecraft.world.WorldServer.throwNotifyNeighborAndCall(WorldServer.java:3120)  
     net.minecraft.world.WorldServer.func_175685_c(WorldServer.java:3093)      
     info.tehnut.soulshardsrespawn.block.TileEntitySoulCage.func_73660_a(TileEntitySoulCage.java:54)
     org.spongepowered.common.event.tracking.TrackingUtil.tickTileEntity(TrackingUtil.java:235) 
     net.minecraft.world.WorldServer.updateTileEntity(WorldServer.java:3167) 
     net.minecraft.world.WorldServer.redirect$onUpdateTileEntities$zme000(WorldServer.java:3151) 
     net.minecraft.world.World.func_72939_s(World.java:6842)
     net.minecraft.world.WorldServer.func_72939_s(WorldServer.java:2290)
     net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:767)
     net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:397)
     net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:668)
    net.minecraft.server.MinecraftServer.run(MinecraftServer.java:526)
```

I hope this provides enough explanation, and if there's something else I can do or explain, by all means.