### PR TITLE
Fix blockstates in multiblock.json

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,9 @@ archivesBaseName = mod_name
 version = "${mc_version}-${mod_version}-${build_number}"
 
 repositories {
-    maven { url "https://tehnut.info/maven/" }
+    //maven { url "https://maven.tehnut.info" }
     maven { url "http://dvs1.progwml6.com/files/maven/" }
+    maven { url "https://github.com/TehNut/temporary-maven-thing/raw/master/maven/" }
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,9 +7,9 @@ forge_version=14.23.2.2641
 mappings_version=snapshot_20180331
 curse_id=291549
 
-hwyla_version=1.8.25-B40_1.12
+hwyla_version=1.8.26-B41_1.12.2
 jei_version=4.8.5.159
 tcon_version=1.12.2-2.9.1.69
 mantle_version=1.12-1.3.1.22
-bm_version=1.12.2-2.2.12-97
-gapi_version=1.12-2.1.5-60
+bm_version=1.12.2-2.4.3-105
+gapi_version=1.12-2.1.8-63

--- a/src/main/java/info/tehnut/soulshardsrespawn/core/data/MultiblockPattern.java
+++ b/src/main/java/info/tehnut/soulshardsrespawn/core/data/MultiblockPattern.java
@@ -158,6 +158,7 @@ public class MultiblockPattern {
                         if (property != null)
                             returnState = returnState.withProperty(property, (Comparable) property.parseValue(valueSplit[1]).get());
                     }
+                    states.add(returnState);
                 } else {
                     states.addAll(ForgeRegistries.BLOCKS.getValue(new ResourceLocation(state)).getBlockState().getValidStates());
                 }


### PR DESCRIPTION
As mentioned in [issue #47](https://github.com/TehNut/Soul-Shards-Respawn/issues/47), using blocks with blockstate specific blockstate does not work. This is a simple fix for it.

Also switches the "https://tehnut.info/maven/" repo to the one on github due to the former being down.